### PR TITLE
Remove obsolete helm-grep-running face

### DIFF
--- a/spacemacs-common.el
+++ b/spacemacs-common.el
@@ -309,7 +309,6 @@
      `(helm-grep-finish ((,class (:foreground ,base :background ,bg1))))
      `(helm-grep-lineno ((,class (:foreground ,base :background ,bg1))))
      `(helm-grep-match ((,class (:foreground nil :background nil :inherit helm-match))))
-     `(helm-grep-running ((,class (:foreground ,func :background ,bg1))))
      `(helm-header ((,class (:foreground ,base :background ,bg1 :underline nil :box nil))))
      `(helm-header-line-left-margin ((,class (:foreground ,inf :background ,nil))))
      `(helm-match ((,class (:inherit match))))


### PR DESCRIPTION
That face got removed in https://github.com/emacs-helm/helm/commit/326c939b09a23f0541ae37c79aeb266d46562da4