### PR TITLE
string delem, operators visible in enh-ruby-mode

### DIFF
--- a/spacemacs-common.el
+++ b/spacemacs-common.el
@@ -222,6 +222,10 @@
 ;;;;; eldoc
      `(eldoc-highlight-function-argument ((,class (:foreground ,(if (eq variant 'dark) suc red) :bold t))))
 
+;;;;; enh-ruby
+     `(enh-ruby-string-delimiter-face ((,class (:foreground ,str))))
+     `(enh-ruby-op-face ((,class (:background ,bg1 :foreground ,base))))
+
 ;;;;; erc
      `(erc-input-face ((,class (:foreground ,func))))
      `(erc-my-nick-face ((,class (:foreground ,key1))))


### PR DESCRIPTION
String delimiters and operators are hardly visible in enh-ruby-mode.
<img width="635" alt="screen shot 2015-10-17 at 2 33 52 pm" src="https://cloud.githubusercontent.com/assets/542810/10558049/57831b10-74df-11e5-9446-d82374322deb.png">

Setting them as seen in python mode (as that's what I use and looked for comparison) for making them visible.
<img width="638" alt="screen shot 2015-10-17 at 2 31 29 pm" src="https://cloud.githubusercontent.com/assets/542810/10558052/9097a998-74df-11e5-89c2-7c0bebebdfb6.png">
