### PR TITLE
add color defn for mu4e-header-key-face

### DIFF
--- a/spacemacs-common.el
+++ b/spacemacs-common.el
@@ -600,6 +600,7 @@
      `(mu4e-cited-1-face ((,class (:foreground ,base))))
      `(mu4e-cited-7-face ((,class (:foreground ,base))))
      `(mu4e-header-marks-face ((,class (:foreground ,comp))))
+     `(mu4e-header-key-face ((,class (:foreground ,head2 :bold t))))
      `(mu4e-view-url-number-face ((,class (:foreground ,comp))))
      `(slime-repl-inputed-output-face ((,class (:foreground ,comp))))
      `(trailing-whitespace ((,class :foreground nil :background ,err)))


### PR DESCRIPTION
I'm not sure what the procedure is for adding new mode-specific bits of theming, so if there's another place I should submit this request then just let me know.

At some stage I guess someone should do a proper "subtheme" for `mu4e`, but for the moment this replaces the a garish bright green (since `mu4e-header-key-face` inherits from `message-header-name`) and seems more pleasing (to me, at least).