### PR TITLE
add colours for man pages

### DIFF
--- a/spacemacs-common.el
+++ b/spacemacs-common.el
@@ -435,6 +435,11 @@
      `(magit-section-highlight      ((,class (:background ,bg2))))
      `(magit-section-title ((,class (:background ,bg1 :foreground ,keyword :weight bold))))
 
+;;;;; man
+     `(Man-overstrike ((,class (:foreground ,head1 :weight bold))))
+     `(Man-reverse ((,class (:foreground ,highlight))))
+     `(Man-underline ((,class (:foreground ,comp :underline t))))
+
 ;;;;; markdown
      `(markdown-header-face-1 ((,class (:bold t :foreground ,head1))))
      `(markdown-header-face-2 ((,class (:bold t :foreground ,head2))))


### PR DESCRIPTION
Another PR to add colors for a mode - in this case `Man-mode`.

Mostly, this is motivated by the fact that I switched to spacemacs-theme from monokai, and there are a few mode-specific colours that I miss. I admit that I'm not a colours-knowing-expert guy, so I'm totally fine if you want to tweak the colors that I've chosen - the main thing I like is that there are *some* pretty colors.

In future, do you want extra mode-specific colors done this way? I'm aware that not everyone likes it to look the way I do. I'd be happy to just set up these colors in my init file, except the way that the theme (and emacs themes in general, it seems) do the name -> colour mapping is a bunch of `let` bindings in a bigol' macro, so it's tricky to use those mappings elsewhere in one's init file. Still, I'm open to suggestions about how to walk the line between having colours where *I* like them, but not imposing them on everyone.

Sorry about the long rant :)