### PR TITLE
Support highlight-symbol.el

### DIFF
--- a/spacemacs-common.el
+++ b/spacemacs-common.el
@@ -388,6 +388,9 @@
 ;;;;; highlight-indentation
      `(highlight-indentation-face ((,class (:background ,comment-bg))))
 
+;;;;; highlight-symbol
+     `(highlight-symbol-face ((,class (:background ,bg2))))
+
 ;;;;; ido
      `(ido-first-match ((,class (:foreground ,comp :inherit bold))))
      `(ido-only-match ((,class (:foreground ,mat :inherit bold))))


### PR DESCRIPTION
Add support for [highlight-symbol.el](https://github.com/nschum/highlight-symbol.el) to highlight occurrences of the symbol at point throughout the current buffer.

Went with `bg2`

<img width="604" alt="screen shot 2016-05-08 at 20 24 35" src="https://cloud.githubusercontent.com/assets/118202/15099693/af437a98-155c-11e6-8bc0-02c79e8bab34.png">

<img width="604" alt="screen shot 2016-05-08 at 20 24 49" src="https://cloud.githubusercontent.com/assets/118202/15099694/b1b8ad52-155c-11e6-9b34-14a5689b1e7f.png">

`act2` also looks good..