### PR TITLE
Change diff-hl faces to be less bright

### DIFF
--- a/spacemacs-common.el
+++ b/spacemacs-common.el
@@ -225,9 +225,9 @@
      `(diff-removed           ((,class :background nil :foreground ,red)))
 
 ;;;;; diff-hl
-     `(diff-hl-change ((,class :background ,keyword :foreground nil)))
-     `(diff-hl-delete ((,class :background ,err :foreground nil)))
-     `(diff-hl-insert ((,class :background ,suc :foreground nil)))
+     `(diff-hl-change ((,class :background ,blue-bg :foreground ,blue)))
+     `(diff-hl-delete ((,class :background ,red-bg :foreground ,red)))
+     `(diff-hl-insert ((,class :background ,green-bg :foreground ,green)))
 
 ;;;;; dired
      `(dired-directory ((,class (:foreground ,keyword :background ,bg1 :inherit bold))))


### PR DESCRIPTION
This was sort of talked about in gitter. This is what I came up with to make it a little less bright. It moves the bg color to the fg and uses the -bg variants for the background.