### PR TITLE
Change fringe background to match linum-mode

### DIFF
--- a/spacemacs-common.el
+++ b/spacemacs-common.el
@@ -159,7 +159,7 @@
      `(font-lock-type-face ((,class (:foreground ,type :inherit bold))))
      `(font-lock-variable-name-face ((,class (:foreground ,var))))
      `(font-lock-warning-face ((,class (:foreground ,war :background ,bg1))))
-     `(fringe ((,class (:background ,bg1 :foreground ,base))))
+     `(fringe ((,class (:background ,bg2 :foreground ,base))))
      `(highlight ((,class (:foreground ,base :background ,highlight))))
      `(hl-line ((,class (:background ,bg2))))
      `(isearch ((,class (:foreground ,bg1 :background ,mat))))


### PR DESCRIPTION
bg1 matches the background of the code... so when the fringe shows up (as with diff-hl) it looks like there are spaces at the start of the line, which can be confusing. This changes the fringe background to match the linum background as they're essentially a part of the same thing (at least in my mind).