### PR TITLE
Theme notmuch.

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,49 +71,50 @@ This allows for specifying a list of custom colors to override spacemacs theme c
 The theme can be customized by overriding one of the theme local variables by setting a list in the `spacemacs-theme-custom-colors` variable.
 Here's a list of all the local variables and roles:
 
-| var        | role                                                                                              |
-|------------|---------------------------------------------------------------------------------------------------|
-| act1       | One of mode-line's active colors.                                                                 |
-| act2       | The other active color of mode-line.                                                              |
-| base       | The basic color of normal text.                                                                   |
-| base-dim   | A dimmer version of the normal text color.                                                        |
-| bg1        | The background color.                                                                             |
-| bg2        | A darker background color. Used to highlight current line.                                        |
-| bg3        | Yet another darker shade of the background color.                                                 |
-| bg4        | The darkest background color.                                                                     |
-| border     | A border line color. Used in mode-line borders.                                                   |
-| cblk       | A code block color. Used in org's code blocks.                                                    |
-| cblk-bg    | The background color of a code block.                                                             |
-| cblk-ln    | A code block header line.                                                                         |
-| cblk-ln-bg | The background of a code block header line.                                                       |
-| cursor     | The cursor/point color.                                                                           |
-| const      | A constant.                                                                                       |
-| comment    | A comment.                                                                                        |
-| comment-bg | The background color of a comment. To disable this, `customize` `spacemacs-theme-comment-bg`.     |
-| comp       | A complementary color.                                                                            |
-| err        | errors.                                                                                           |
-| func       | functions.                                                                                        |
-| head1      | Level 1 of a heading. Used in org's headings.                                                     |
-| head1-bg   | The background of level 2 headings. To disable this, `customize` `spacemacs-theme-org-highlight`. |
-| head2      | Level 2 headings.                                                                                 |
-| head2-bg   | Level 2 headings background.                                                                      |
-| head3      | Level 3 headings.                                                                                 |
-| head3-bg   | Level 3 headings background.                                                                      |
-| head4      | Level 4 headings.                                                                                 |
-| head4-bg   | Level 4 headings background.                                                                      |
-| highlight  | A highlighted area.                                                                               |
-| keyword    | A keyword or a builtin color.                                                                     |
-| lnum       | Line numbers.                                                                                     |
-| mat        | A matched color. Used in matching parens, brackets and tags.                                      |
-| meta       | A meta line. Used in org's meta line.                                                             |
-| str        | A string.                                                                                         |
-| suc        | To indicate success. Opposite of error.                                                           |
-| ttip       | Tooltip color.                                                                                    |
-| ttip-sl    | Tooltip selection color.                                                                          |
-| ttip-bg    | Tooltip background color.                                                                         |
-| type       | A type color.                                                                                     |
-| var        | A variable color.                                                                                 |
-| war        | A warning color.                                                                                  |
+| var           | role                                                                                              |
+|---------------|---------------------------------------------------------------------------------------------------|
+| act1          | One of mode-line's active colors.                                                                 |
+| act2          | The other active color of mode-line.                                                              |
+| base          | The basic color of normal text.                                                                   |
+| base-dim      | A dimmer version of the normal text color.                                                        |
+| bg1           | The background color.                                                                             |
+| bg2           | A darker background color. Used to highlight current line.                                        |
+| bg3           | Yet another darker shade of the background color.                                                 |
+| bg4           | The darkest background color.                                                                     |
+| border        | A border line color. Used in mode-line borders.                                                   |
+| cblk          | A code block color. Used in org's code blocks.                                                    |
+| cblk-bg       | The background color of a code block.                                                             |
+| cblk-ln       | A code block header line.                                                                         |
+| cblk-ln-bg    | The background of a code block header line.                                                       |
+| cursor        | The cursor/point color.                                                                           |
+| const         | A constant.                                                                                       |
+| comment       | A comment.                                                                                        |
+| comment-bg    | The background color of a comment. To disable this, `customize` `spacemacs-theme-comment-bg`.     |
+| comp          | A complementary color.                                                                            |
+| err           | errors.                                                                                           |
+| func          | functions.                                                                                        |
+| head1         | Level 1 of a heading. Used in org's headings.                                                     |
+| head1-bg      | The background of level 2 headings. To disable this, `customize` `spacemacs-theme-org-highlight`. |
+| head2         | Level 2 headings.                                                                                 |
+| head2-bg      | Level 2 headings background.                                                                      |
+| head3         | Level 3 headings.                                                                                 |
+| head3-bg      | Level 3 headings background.                                                                      |
+| head4         | Level 4 headings.                                                                                 |
+| head4-bg      | Level 4 headings background.                                                                      |
+| highlight     | A highlighted area.                                                                               |
+| highlight-dim | A dimmer highlighted area.                                                                        |
+| keyword       | A keyword or a builtin color.                                                                     |
+| lnum          | Line numbers.                                                                                     |
+| mat           | A matched color. Used in matching parens, brackets and tags.                                      |
+| meta          | A meta line. Used in org's meta line.                                                             |
+| str           | A string.                                                                                         |
+| suc           | To indicate success. Opposite of error.                                                           |
+| ttip          | Tooltip color.                                                                                    |
+| ttip-sl       | Tooltip selection color.                                                                          |
+| ttip-bg       | Tooltip background color.                                                                         |
+| type          | A type color.                                                                                     |
+| var           | A variable color.                                                                                 |
+| war           | A warning color.                                                                                  |
 
 
 There is also explicit colors variables that can be customized:

--- a/spacemacs-common.el
+++ b/spacemacs-common.el
@@ -108,6 +108,7 @@
         (head4         (if (eq variant 'dark) (if (true-color-p) "#b1951d" "#875f00") (if (true-color-p) "#b1951d" "#875f00")))
         (head4-bg      (if (eq variant 'dark) (if (true-color-p) "#32322c" "#262626") (if (true-color-p) "#f6f1e1" "#ffffff")))
         (highlight     (if (eq variant 'dark) (if (true-color-p) "#444155" "#444444") (if (true-color-p) "#d3d3e7" "#d7d7ff")))
+        (highlight-dim (if (eq variant 'dark) (if (true-color-p) "#3b314d" "#444444") (if (true-color-p) "#e7e7fc" "#d7d7ff")))
         (keyword       (if (eq variant 'dark) (if (true-color-p) "#4f97d7" "#268bd2") (if (true-color-p) "#3a81c3" "#268bd2")))
         (lnum          (if (eq variant 'dark) (if (true-color-p) "#44505c" "#444444") (if (true-color-p) "#a8a8bf" "#af87af")))
         (mat           (if (eq variant 'dark) (if (true-color-p) "#86dc2f" "#86dc2f") (if (true-color-p) "#ba2f59" "#af005f")))
@@ -541,6 +542,14 @@
      `(mu4e-header-key-face ((,class (:foreground ,head2 :inherit bold))))
      `(mu4e-view-url-number-face ((,class (:foreground ,comp))))
      `(mu4e-unread-face ((,class (:foreground ,yellow :inherit bold))))
+
+;;;;; notmuch
+     `(notmuch-search-date ((,class (:foreground ,func))))
+     `(notmuch-search-flagged-face ((,class (:weight extra-bold))))
+     `(notmuch-search-non-matching-authors ((,class (:foreground ,base-dim))))
+     `(notmuch-search-unread-face ((,class (:background ,highlight-dim :box ,border))))
+     `(notmuch-tag-face ((,class (:foreground ,keyword))))
+     `(notmuch-tag-flagged ((,class (:foreground ,war))))
 
 ;;;;; neotree
      `(neo-dir-link-face ((,class (:foreground ,keyword :inherit bold))))


### PR DESCRIPTION
This also adds a `highlight-dim` color for, well, dimmer highlights. Here I use
it for highlighting unread email.