### PR TITLE
Add additional support for elfeed's date face

### DIFF
--- a/spacemacs-common.el
+++ b/spacemacs-common.el
@@ -286,6 +286,7 @@
      `(elfeed-search-unread-title-face ((,class (:foreground ,base))))
      `(elfeed-search-feed-face ((,class (:foreground ,blue))))
      `(elfeed-search-tag-face ((,class (:foreground ,func))))
+     `(elfeed-search-date-face ((,class (:foreground ,head2))))
 
 ;;;;; enh-ruby
      `(enh-ruby-string-delimiter-face ((,class (:foreground ,str))))


### PR DESCRIPTION
This patch themes `elfeed-search-date-face`, employing one of the provided header colours. I've chosen `head2` over `head1` because of the latter's similarity to the face used for the feed itself.

At present, the theme does not provide any styling for this face. This is how it currently looks:

![Before](https://cloud.githubusercontent.com/assets/1448326/21667171/a800a406-d2c4-11e6-8d14-4395de009e79.png)

And with the new `head2` colour:

![After](https://cloud.githubusercontent.com/assets/1448326/21667186/c5d9872c-d2c4-11e6-8c66-3484ddfa2d02.png)