### PR TITLE
Make mu4e-maildirs headers head2

### DIFF
--- a/spacemacs-common.el
+++ b/spacemacs-common.el
@@ -570,6 +570,9 @@
      `(mu4e-unread-face ((,class (:foreground ,type :inherit bold))))
      `(mu4e-view-url-number-face ((,class (:foreground ,comp))))
 
+;;;;; mu4e-maildirs
+     `(mu4e-maildirs-extension-maildir-hl-face ((,class (:foreground ,head2 :inherit bold))))
+
 ;;;;; notmuch
      `(notmuch-search-date ((,class (:foreground ,func))))
      `(notmuch-search-flagged-face ((,class (:weight extra-bold))))


### PR DESCRIPTION
Thanks for themeing mu4e! 

This is a small fix. mu4e-maildirs is an extension that shows the maildirs separately in mu4e. Right now they show up as a weird pinkish color, this makes it so that they get the "head2" color.