### PR TITLE
Add custom option to enable italics for comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ The theme has some options that can be tweaked via `M-x customize`:
 
 This toggles a background color for the comment lines.
 
+* `spacemacs-theme-comment-italic`:
+
+This toggles italics for comments and will also add a lighter color to it. It is recommended to disable `spacemacs-theme-comment-bg` if you turn this option on for better contrast.
+
 * `spacemacs-theme-org-agenda-height`:
 
 This toggles the use of varying org agenda heights.

--- a/spacemacs-common.el
+++ b/spacemacs-common.el
@@ -46,6 +46,11 @@
   :type 'boolean
   :group 'spacemacs-theme)
 
+(defcustom spacemacs-theme-comment-italic nil
+  "Enable italics for comments and also disable background."
+  :type 'boolean
+  :group 'spacemacs-theme)
+
 (defcustom spacemacs-theme-org-agenda-height t
   "Use varying text heights for org agenda."
   :type 'boolean
@@ -62,7 +67,7 @@
   :group 'spacemacs-theme)
 
 (defcustom spacemacs-theme-custom-colors nil
-  "Specify a list of custom colors"
+  "Specify a list of custom colors."
   :type 'alist
   :group 'spacemacs-theme)
 
@@ -95,6 +100,7 @@
         (cursor        (if (eq variant 'dark) (if (true-color-p) "#e3dedd" "#d0d0d0") (if (true-color-p) "#100a14" "#121212")))
         (const         (if (eq variant 'dark) (if (true-color-p) "#a45bad" "#d75fd7") (if (true-color-p) "#4e3163" "#8700af")))
         (comment       (if (eq variant 'dark) (if (true-color-p) "#2aa1ae" "#008787") (if (true-color-p) "#2aa1ae" "#008787")))
+        (comment-light (if (eq variant 'dark) (if (true-color-p) "#2aa1ae" "#008787") (if (true-color-p) "#a49da5" "#008787")))
         (comment-bg    (if (eq variant 'dark) (if (true-color-p) "#292e34" "#262626") (if (true-color-p) "#ecf3ec" "#ffffff")))
         (comp          (if (eq variant 'dark) (if (true-color-p) "#c56ec3" "#d75fd7") (if (true-color-p) "#6c4173" "#8700af")))
         (err           (if (eq variant 'dark) (if (true-color-p) "#e0211d" "#e0211d") (if (true-color-p) "#e0211d" "#e0211d")))
@@ -153,7 +159,7 @@
      `(eval-sexp-fu-flash ((,class (:background ,suc :foreground ,bg1))))
      `(eval-sexp-fu-flash-error ((,class (:background ,err :foreground ,bg1))))
      `(font-lock-builtin-face ((,class (:foreground ,keyword))))
-     `(font-lock-comment-face ((,class (:foreground ,comment :background ,(when spacemacs-theme-comment-bg comment-bg)))))
+     `(font-lock-comment-face ((,class (:foreground ,(if spacemacs-theme-comment-italic comment-light comment) :background ,(when spacemacs-theme-comment-bg comment-bg) :slant ,(if spacemacs-theme-comment-italic 'italic 'normal)))))
      `(font-lock-constant-face ((,class (:foreground ,const))))
      `(font-lock-doc-face ((,class (:foreground ,comment))))
      `(font-lock-function-name-face ((,class (:foreground ,func :inherit bold))))


### PR DESCRIPTION
This PR adds an option to enable italics for comments.

## Notes

- By default the new option is disabled (for backwards compatibility)
- Recommendation is once new option is enabled, comment bg option should be disabled (for better contrast)
- Add a new `comment-light` color, for better looking comments once italics are turned on

## Screenshots

◉ `spacemacs-theme-comment-bg`
◯ `spacemacs-theme-comment-italic`

![spacemacs-theme-comment-italic-1](https://user-images.githubusercontent.com/87162/28120459-1a42db6e-66e6-11e7-8594-7dff37d507fc.jpg)

◉ `spacemacs-theme-comment-bg`
◉ `spacemacs-theme-comment-italic`

![spacemacs-theme-italic-2](https://user-images.githubusercontent.com/87162/28120460-1a46cb0c-66e6-11e7-9163-353dc94b3707.jpg)

◯ `spacemacs-theme-comment-bg`
◉ `spacemacs-theme-comment-italic`

![spacemacs-theme-italic-3](https://user-images.githubusercontent.com/87162/28120461-1a4638d6-66e6-11e7-83e9-30536ab8e895.jpg)
