### PR TITLE
Fix org-agenda tag alignment

### DIFF
--- a/spacemacs-common.el
+++ b/spacemacs-common.el
@@ -51,8 +51,8 @@
   :type 'boolean
   :group 'spacemacs-theme)
 
-(defcustom spacemacs-theme-org-agenda-height t
-  "Use varying text heights for org agenda."
+(defcustom spacemacs-theme-org-agenda-height nil
+  "If non-nil, use varying text heights for agenda items."
   :type 'boolean
   :group 'spacemacs-theme)
 

--- a/spacemacs-common.el
+++ b/spacemacs-common.el
@@ -52,7 +52,11 @@
   :group 'spacemacs-theme)
 
 (defcustom spacemacs-theme-org-agenda-height nil
-  "If non-nil, use varying text heights for agenda items."
+  "If non-nil, use varying text heights for agenda items.
+
+Note that if you change this to a non-nil value, you may want to
+also adjust the value of `org-agenda-tags-column'. If that is set
+to 'auto, tags may not be properly aligned. "
   :type 'boolean
   :group 'spacemacs-theme)
 


### PR DESCRIPTION
Org 9.1 makes 'auto the default value for org-agenda-align-tags-to-column, which
pushes tags to the right of the agenda window. If we change the height of agenda
items, though, this pushes them too far, resulting in ugly line wrapping.