### PR TITLE
Use the same face for whitespace tabs as for spaces

### DIFF
--- a/spacemacs-common.el
+++ b/spacemacs-common.el
@@ -811,7 +811,7 @@ to 'auto, tags may not be properly aligned. "
      `(whitespace-space ((,class (:background nil :foreground ,act2))))
      `(whitespace-space-after-tab ((,class (:background nil :foreground ,yellow))))
      `(whitespace-space-before-tab ((,class (:background nil :foreground ,yellow))))
-     `(whitespace-tab ((,class (:background nil))))
+     `(whitespace-tab ((,class (:background nil :foreground ,act2))))
      `(whitespace-trailing ((,class (:background ,err :foreground ,war))))
 
 ;;;;; other, need more work


### PR DESCRIPTION
When using whitespace mode I turn both, spaces and tabs to see what is used where and how. This way tabs don't obscure the view as they do with the default foreground. Make them look the same the spaces do now.