### PR TITLE
add support for pdf-view-midnight-minor-mode

### DIFF
--- a/spacemacs-common.el
+++ b/spacemacs-common.el
@@ -917,8 +917,10 @@ to 'auto, tags may not be properly aligned. "
 
     (custom-theme-set-variables
      theme-name
-     `(ansi-color-names-vector [,bg4 ,red ,green ,yellow ,blue ,magenta ,cyan ,base]))
+     `(ansi-color-names-vector [,bg4 ,red ,green ,yellow ,blue ,magenta ,cyan ,base])
 
+;;;;; pdf-tools
+    `(pdf-view-midnight-colors '(,base . ,bg1)))
     ))
 
 


### PR DESCRIPTION
The `pdf-tools` package has a `pdf-view-midnight-minor-mode` with bright text on dark background. Using `spacemacs-light/dark` colors makes it look nicer.