### PR TITLE
Add web-mode-current-element-highlight-face

### DIFF
--- a/spacemacs-common.el
+++ b/spacemacs-common.el
@@ -868,6 +868,7 @@ to 'auto, tags may not be properly aligned. "
      `(web-mode-builtin-face ((,class (:inherit ,font-lock-builtin-face))))
      `(web-mode-comment-face ((,class (:inherit ,font-lock-comment-face))))
      `(web-mode-constant-face ((,class (:inherit ,font-lock-constant-face))))
+     `(web-mode-current-element-highlight-face ((,class (:background ,bg3))))
      `(web-mode-doctype-face ((,class (:inherit ,font-lock-comment-face))))
      `(web-mode-function-name-face ((,class (:inherit ,font-lock-function-name-face))))
      `(web-mode-html-attr-name-face ((,class (:foreground ,func))))


### PR DESCRIPTION
Hi! Did I mentioned earlier that spacemacs-theme rulezzz? :D

Anyways, I've added a handler for web-mode's current element highlighting. Tried couple existing (and new) colors and decided to try `bg3`. Couple screenshots:

## Before:
![spacemacs_default](https://user-images.githubusercontent.com/7038954/46610771-5fb0b200-cb14-11e8-8aac-d89c34288385.png)
![default_dark](https://user-images.githubusercontent.com/7038954/46610783-6a6b4700-cb14-11e8-8c1a-18877e2dbd94.png)

## After:
![spacemacs_after](https://user-images.githubusercontent.com/7038954/46610821-85d65200-cb14-11e8-8bb4-c681e3621769.png)
![spacemacs_after_dark](https://user-images.githubusercontent.com/7038954/46610823-8838ac00-cb14-11e8-898d-75c2d274cfaa.png)

What do you think? Hope it'll be useful!
Much love