### PR TITLE
Set line-number face unconditionally

### DIFF
--- a/spacemacs-common.el
+++ b/spacemacs-common.el
@@ -594,9 +594,8 @@ to 'auto, tags may not be properly aligned. "
      `(linum ((,class (:foreground ,lnum :background ,bg2 :inherit default))))
 
 ;;;;; display-line-numbers-mode (Emacs 26+)
-     (when (>= emacs-major-version 26)
-       `(line-number ((,class (:foreground ,lnum :background ,bg2))))
-       `(line-number-current-line ((,class (:foreground ,base :background ,bg2)))))
+     `(line-number ((,class (:foreground ,lnum :background ,bg2 :inherit default))))
+     `(line-number-current-line ((,class (:foreground ,base :background ,bg2 :inherit line-number))))
 
 ;;;;; linum-relative
      `(linum-relative-current-face ((,class (:foreground ,comp))))


### PR DESCRIPTION
Fixes a bug with line-number faces originally reported at spacemacs: https://github.com/syl20bnr/spacemacs/issues/10877
Exact details of the bug at https://github.com/syl20bnr/spacemacs/issues/10877#issuecomment-434372597, but in short the code just didn't do what it's supposed to do.

I've opted for removing the `when` condition, instead of the other proposed solution (two `when` expressions, one for each face), because it is cleaner. The faces being non-existent in Emacs 25.3 didn't cause any problems for me. Tested by running Spacemacs with modified spacemacs-theme files on Emacs 25.3 and Emacs 26.1.