### PR TITLE
Unify ediff-current-diff-{A,B,C} background colors

### DIFF
--- a/spacemacs-common.el
+++ b/spacemacs-common.el
@@ -310,10 +310,10 @@ to 'auto, tags may not be properly aligned. "
      `(dired-warning ((,class (:foreground ,war))))
 
 ;;;;; ediff
-     `(ediff-current-diff-A ((,class(:background ,red-bg-s :foreground ,red))))
+     `(ediff-current-diff-A ((,class(:background ,red-bg :foreground ,red))))
      `(ediff-current-diff-Ancestor ((,class(:background ,aqua-bg :foreground ,aqua))))
-     `(ediff-current-diff-B ((,class(:background ,green-bg-s :foreground ,green))))
-     `(ediff-current-diff-C ((,class(:background ,blue-bg-s :foreground ,blue))))
+     `(ediff-current-diff-B ((,class(:background ,green-bg :foreground ,green))))
+     `(ediff-current-diff-C ((,class(:background ,blue-bg :foreground ,blue))))
      `(ediff-even-diff-A ((,class(:background ,bg3))))
      `(ediff-even-diff-Ancestor ((,class(:background ,bg3))))
      `(ediff-even-diff-B ((,class(:background ,bg3))))

--- a/spacemacs-common.el
+++ b/spacemacs-common.el
@@ -313,7 +313,7 @@ to 'auto, tags may not be properly aligned. "
      `(ediff-current-diff-A ((,class(:background ,red-bg-s :foreground ,red))))
      `(ediff-current-diff-Ancestor ((,class(:background ,aqua-bg :foreground ,aqua))))
      `(ediff-current-diff-B ((,class(:background ,green-bg-s :foreground ,green))))
-     `(ediff-current-diff-C ((,class(:background ,blue-bg :foreground ,blue))))
+     `(ediff-current-diff-C ((,class(:background ,blue-bg-s :foreground ,blue))))
      `(ediff-even-diff-A ((,class(:background ,bg3))))
      `(ediff-even-diff-Ancestor ((,class(:background ,bg3))))
      `(ediff-even-diff-B ((,class(:background ,bg3))))


### PR DESCRIPTION
Problem: The `ediff-current-diff-{A, B}` faces use the `red-bg-s` and `green-bg-s` colors, but the `ediff-current-diff-C` face use the non `-s`, `blue-bg` colors.
Solution: use the `blue-bg-s` color for the `ediff-current-diff-C` face.

---

### Before

![emacs_2018-12-21_17-44-43](https://user-images.githubusercontent.com/13420573/50353723-6a8eb680-0549-11e9-98ac-a0bb16c9c069.png)
![emacs_2018-12-21_17-37-45](https://user-images.githubusercontent.com/13420573/50353730-6fec0100-0549-11e9-973c-c285908def8e.png)

### After

![emacs_2018-12-21_17-43-47](https://user-images.githubusercontent.com/13420573/50353749-7b3f2c80-0549-11e9-9161-6fbee53a92d9.png)
![emacs_2018-12-21_17-42-20](https://user-images.githubusercontent.com/13420573/50353756-7e3a1d00-0549-11e9-9bf8-e3bdb717caf3.png)
