### PR TITLE
Change diff refine fg to match ediff fine diff fg

### DIFF
--- a/spacemacs-common.el
+++ b/spacemacs-common.el
@@ -288,9 +288,9 @@ to 'auto, tags may not be properly aligned. "
      `(diff-indicator-added   ((,class :background nil :foreground ,green)))
      `(diff-indicator-changed ((,class :background nil :foreground ,blue)))
      `(diff-indicator-removed ((,class :background nil :foreground ,red)))
-     `(diff-refine-added      ((,class :background ,green :foreground ,bg4)))
-     `(diff-refine-changed    ((,class :background ,blue :foreground ,bg4)))
-     `(diff-refine-removed    ((,class :background ,red :foreground ,bg4)))
+     `(diff-refine-added      ((,class :background ,green :foreground ,bg1)))
+     `(diff-refine-changed    ((,class :background ,blue :foreground ,bg1)))
+     `(diff-refine-removed    ((,class :background ,red :foreground ,bg1)))
      `(diff-removed           ((,class :background nil :foreground ,red)))
 
 ;;;;; diff-hl


### PR DESCRIPTION
This also makes the light themes diff refined text much more readable.

### Before

![emacs_2019-01-14_09-07-55](https://user-images.githubusercontent.com/13420573/51101898-0627e580-17dd-11e9-9e51-0de1a0ce4463.png)



### After

![emacs_2019-01-14_09-10-31](https://user-images.githubusercontent.com/13420573/51101905-0aec9980-17dd-11e9-837d-a428be19a33d.png)

### Notes

There's no major difference between the dark themes before and after screenshots, so I only included the light theme.