### PR TITLE
Added selected/unselected modified face for tabbar

### DIFF
--- a/spacemacs-common.el
+++ b/spacemacs-common.el
@@ -849,6 +849,7 @@ to 'auto, tags may not be properly aligned. "
      `(tabbar-default ((,class (:background ,bg1 :foreground ,head1 :height 0.9))))
      `(tabbar-highlight ((,class (:underline t))))
      `(tabbar-selected ((,class (:inherit tabbar-default :foreground ,func :weight bold))))
+     `(tabbar-selected-modified ((,class (:inherit tabbar-default :foreground ,red :weight bold))))
      `(tabbar-separator ((,class (:inherit tabbar-default))))
      `(tabbar-unselected ((,class (:inherit tabbar-default :background ,bg1 :slant italic :weight light))))
      `(tabbar-unselected-modified ((,class (:inherit tabbar-unselected :background ,bg1 :foreground ,red))))

--- a/spacemacs-common.el
+++ b/spacemacs-common.el
@@ -851,6 +851,7 @@ to 'auto, tags may not be properly aligned. "
      `(tabbar-selected ((,class (:inherit tabbar-default :foreground ,func :weight bold))))
      `(tabbar-separator ((,class (:inherit tabbar-default))))
      `(tabbar-unselected ((,class (:inherit tabbar-default :background ,bg1 :slant italic :weight light))))
+     `(tabbar-unselected-modified ((,class (:inherit tabbar-unselected :background ,bg1 :foreground ,red))))
 
 ;;;;; term
      `(term ((,class (:foreground ,base :background ,bg1))))


### PR DESCRIPTION
Just noticed that tabbar did't had an unselected modified face so decided to add it so it looks better. Here's how it looks:
![spacemacs](https://user-images.githubusercontent.com/17773218/53614689-5cd85b80-3ba0-11e9-8efe-4f5adf772d07.png)
