### PR TITLE
Make sure custom themes can change all color variables

### DIFF
--- a/spacemacs-common.el
+++ b/spacemacs-common.el
@@ -162,8 +162,8 @@ to 'auto, tags may not be properly aligned. "
         (yellow        (if (eq variant 'dark) (if (true-color-p) "#b1951d" "#875f00") (if (true-color-p) "#b1951d" "#875f00")))
         (yellow-bg     (if (eq variant 'dark) (if (true-color-p) "#32322c" "#262626") (if (true-color-p) "#f6f1e1" "#ffffff"))))
 
-    (cl-loop for (var . val) in spacemacs-theme-custom-colors
-             do (set var val))
+    (cl-loop for (cvar . val) in spacemacs-theme-custom-colors
+             do (set cvar val))
 
     (custom-theme-set-faces
      theme-name


### PR DESCRIPTION
Fixes issue where the local variable used in the loop for setting custom theme colors conflicted with an existing color variable. This fixes problem discussed in #151