### PR TITLE
Fix term colors

### DIFF
--- a/spacemacs-common.el
+++ b/spacemacs-common.el
@@ -877,14 +877,14 @@ to 'auto, tags may not be properly aligned. "
 
 ;;;;; term
      `(term ((,class (:foreground ,base :background ,bg1))))
-     `(term-color-black ((,class (:foreground ,bg4))))
-     `(term-color-blue ((,class (:foreground ,keyword))))
-     `(term-color-cyan ((,class (:foreground ,cyan))))
-     `(term-color-green ((,class (:foreground ,green))))
-     `(term-color-magenta ((,class (:foreground ,magenta))))
-     `(term-color-red ((,class (:foreground ,red))))
-     `(term-color-white ((,class (:foreground ,base))))
-     `(term-color-yellow ((,class (:foreground ,yellow))))
+     `(term-color-black ((,class (:foreground ,bg4 :background ,bg4))))
+     `(term-color-blue ((,class (:foreground ,keyword :background ,keyword))))
+     `(term-color-cyan ((,class (:foreground ,cyan :background ,cyan))))
+     `(term-color-green ((,class (:foreground ,green :background ,green))))
+     `(term-color-magenta ((,class (:foreground ,magenta :background ,magenta))))
+     `(term-color-red ((,class (:foreground ,red :background ,red))))
+     `(term-color-white ((,class (:foreground ,base :background ,base))))
+     `(term-color-yellow ((,class (:foreground ,yellow :background ,yellow))))
 
 ;;;;; tide
      `(tide-hl-identifier-face ((,class (:foreground ,yellow :background ,yellow-bg))))


### PR DESCRIPTION
The `term-color-*` faces are weird in that they need both `:foreground` and `:background` set in order to work correctly.

https://raw.githubusercontent.com/fikovnik/bin-scripts/master/color-test.sh does not work correctly on the current version, the background does not change at all. I initially thought it was wrong but this change seems to work, at least for me.

The Nord theme does this as well: https://github.com/arcticicestudio/nord-emacs/blob/2fc8fe41105d995a8c5d2bad0443ad3ae45c2573/nord-theme.el#L278-L285