### PR TITLE
Add support for ivy-posframe

### DIFF
--- a/spacemacs-common.el
+++ b/spacemacs-common.el
@@ -584,6 +584,9 @@ to 'auto, tags may not be properly aligned. "
      `(ivy-minibuffer-match-face-3 ((,class (:foreground ,head4 :underline t))))
      `(ivy-minibuffer-match-face-4 ((,class (:foreground ,head3 :underline t))))
      `(ivy-remote ((,class (:foreground ,cyan))))
+     
+;;;;; ivy-posframe
+     `(ivy-posframe ((,class (:background ,bg3))))
 
 ;;;;; latex
      `(font-latex-bold-face ((,class (:foreground ,comp))))


### PR DESCRIPTION
This pull request is needed to distinguish the different backgrounds between the posframe and the open buffer **when solaire-mode is enabled**.

Here's a quick before-and-after, using the **scratch** buffer as an example for solaire-mode. Note the **lack** of contrast if ivy-posframe share the same background color as the open buffer.

### Before:
![Screenshot 2020-01-27 at 22 45 44](https://user-images.githubusercontent.com/36686900/73184149-f1ec2780-4156-11ea-81de-f94611f56a17.png)

### After:
![Screenshot 2020-01-27 at 22 44 57](https://user-images.githubusercontent.com/36686900/73184187-02040700-4157-11ea-9029-d2a45a742c83.png)
