### PR TITLE
Make company tooltip common faces consistent

### DIFF
--- a/spacemacs-common.el
+++ b/spacemacs-common.el
@@ -280,7 +280,7 @@ to 'auto, tags may not be properly aligned. "
      `(company-tooltip ((,class (:background ,ttip-bg :foreground ,ttip))))
      `(company-tooltip-annotation ((,class (:foreground ,type))))
      `(company-tooltip-common ((,class (:background ,ttip-bg :foreground ,keyword))))
-     `(company-tooltip-common-selection ((,class (:foreground ,base))))
+     `(company-tooltip-common-selection ((,class (:foreground ,keyword))))
      `(company-tooltip-mouse ((,class (:inherit highlight))))
      `(company-tooltip-search ((,class (:inherit match))))
      `(company-tooltip-selection ((,class (:background ,ttip-sl :foreground ,base))))


### PR DESCRIPTION
I'm not sure if this is an intentional decision or potentially a bug. But normally (as found in most other modern editors), users would expect the tooltip common faces of candidates to be highlighted whether being selected or not. I find the behaviour to disable the common highlight when the candidate is selected to be inconsistent, and at times, confusing and less expressive.
Please keep me updated of your decision, looking forward that this'll be fixed :)