### PR TITLE
Add some lsp-mode faces

### DIFF
--- a/spacemacs-common.el
+++ b/spacemacs-common.el
@@ -624,6 +624,9 @@ to 'auto, tags may not be properly aligned. "
      `(linum-relative-current-face ((,class (:foreground ,comp))))
 
 ;;;;; lsp
+     `(lsp-ui-doc-background ((,class (:background ,bg2))))
+     `(lsp-ui-doc-header ((,class (:foreground ,head1 :background ,head1-bg))))
+
      `(lsp-ui-sideline-code-action ((,class (:foreground ,comp))))
 
 ;;;;; magit

--- a/spacemacs-common.el
+++ b/spacemacs-common.el
@@ -623,6 +623,9 @@ to 'auto, tags may not be properly aligned. "
 ;;;;; linum-relative
      `(linum-relative-current-face ((,class (:foreground ,comp))))
 
+;;;;; lsp
+     `(lsp-ui-sideline-code-action ((,class (:foreground ,comp))))
+
 ;;;;; magit
      `(magit-blame-culprit ((,class :background ,yellow-bg :foreground ,yellow)))
      `(magit-blame-date    ((,class :background ,yellow-bg :foreground ,green)))


### PR DESCRIPTION
Added faces for the lsp-mode features I use. This should fix #143 since that face is lsp-ui-sideline-code-action, though I’m not sure comp is the right color. (That face is used for actions you can click to modify the code at point in particular ways. Clangd for C/C++ offers to expand preprocessor macros f.ex.)