### PR TITLE
[emacs27] add :extend for ivy-current-match

### DIFF
--- a/spacemacs-common.el
+++ b/spacemacs-common.el
@@ -583,7 +583,7 @@ to 'auto, tags may not be properly aligned. "
      `(info-title-4 ((,class (:height 1.2))))
 
 ;;;;; ivy
-     `(ivy-current-match ((,class (:background ,highlight :inherit bold))))
+     `(ivy-current-match ((,class (:background ,highlight :inherit bold :extend t))))
      `(ivy-minibuffer-match-face-1 ((,class (:inherit bold))))
      `(ivy-minibuffer-match-face-2 ((,class (:foreground ,head1 :underline t))))
      `(ivy-minibuffer-match-face-3 ((,class (:foreground ,head4 :underline t))))


### PR DESCRIPTION
It is required per ivy-format-function-line doc string:
```
"... Note that since Emacs 27, ‘ivy-current-match’ needs to have :extend t attribute.
It has it by default, but the current theme also needs to set it."
```