### PR TITLE
Update org-column face to use default height

### DIFF
--- a/spacemacs-common.el
+++ b/spacemacs-common.el
@@ -746,7 +746,7 @@ to 'auto, tags may not be properly aligned. "
      `(org-block-end-line ((,class (:background ,cblk-ln-bg :foreground ,cblk-ln :extend t))))
      `(org-clock-overlay ((,class (:foreground ,comp))))
      `(org-code ((,class (:foreground ,cyan))))
-     `(org-column ((,class (:background ,highlight))))
+     `(org-column ((,class (:background ,highlight :inherit ,(if spacemacs-theme-org-height 'default)))))
      `(org-column-title ((,class (:background ,highlight))))
      `(org-date ((,class (:underline t :foreground ,var))))
      `(org-date-selected ((,class (:background ,func :foreground ,bg1))))


### PR DESCRIPTION
If using spacemacs-theme with `spacemacs-theme-org-height` set to `t`, then `org-mode` headings of level 1-3 will have non-standard heights so that higher level headlines "stick out" more, which is aesthetically pleasing. However, if one enables `org-columns` (with e.g., `C-c C-x C-c`), then things will be misaligned (see [this issue on `spacemacs` repo](https://github.com/syl20bnr/spacemacs/issues/14058)), since the column headers are (likely) using the standard face height, but any level 1-3 headers that appear in the column view table will have differing heights.

The `org-column` face is overlaid on top of `org-level-{1,2,3}` but any unspecified lower attributes "shine through" and thus different rows of the "table" generated by `org-columns` have different `height` and so things don't line up properly. 

This commit explicitly sets the `:height:` attribute of the `org-column` face to whatever the `:height` of the `default` face is.