### PR TITLE
Improve handling of auto-highlight-symbol

### DIFF
--- a/spacemacs-common.el
+++ b/spacemacs-common.el
@@ -215,7 +215,12 @@ to 'auto, tags may not be properly aligned. "
 
 ;;;;; ahs
      `(ahs-face ((,class (:background ,highlight))))
+     `(ahs-face-unfocused ((,class (:background ,highlight))))
+     `(ahs-definition-face ((,class (:background ,highlight))))
+     `(ahs-definition-face-unfocused ((,class (:background ,highlight))))
      `(ahs-plugin-whole-buffer-face ((,class (:background ,mat :foreground ,bg1))))
+     `(ahs-plugin-default-face ((,class (:background ,highlight))))
+     `(ahs-plugin-default-face-unfocused ((,class (:background ,highlight))))
 
 ;;;;; anzu-mode
      `(anzu-mode-line ((,class (:foreground ,yellow :inherit bold))))


### PR DESCRIPTION
Upstream introduced several new faces as well fixed typo in the name of an existing face name (`ahs-plugin-defalt-face`). This commit fixes these issues by applying unobtrusive background highlighting, the same way it is already implemented for `ahs-face`.

Here are screenshots from my Spacemacs setup. Before:
![spacemacs-theme-before](https://user-images.githubusercontent.com/2280844/124473843-7b6e4300-dda8-11eb-901b-6bc69d189455.png)

After:
![spacemacs-theme-after](https://user-images.githubusercontent.com/2280844/124473876-83c67e00-dda8-11eb-84f3-f9b4aa4c2d8b.png)

fixes: #186 