### PR TITLE
Bump version to 0.2 for NonGNU ELPA

### DIFF
--- a/spacemacs-common.el
+++ b/spacemacs-common.el
@@ -5,7 +5,7 @@
 ;; Author: Nasser Alshammari
 ;; URL: <https://github.com/nashamri/spacemacs-theme>
 ;;
-;; Version: 0.1
+;; Version: 0.2
 ;; Keywords: color, theme
 ;; Package-Requires: ((emacs "24"))
 

--- a/spacemacs-theme-pkg.el
+++ b/spacemacs-theme-pkg.el
@@ -1,1 +1,1 @@
-(define-package "spacemacs-theme" "0.1" "Color theme with a dark and light versions" 'nil :url "https://github.com/nashamri/spacemacs-theme" :keywords '("color" "theme"))
+(define-package "spacemacs-theme" "0.2" "Color theme with a dark and light versions" 'nil :url "https://github.com/nashamri/spacemacs-theme" :keywords '("color" "theme"))


### PR DESCRIPTION
Hi!

I am investigating if we could add this package to [NonGNU ELPA](http://elpa.nongnu.org/) (see link), a new Emacs Lisp package archive that will be enabled by default in Emacs 28. This means that users of that version or later will be able to install this package without any configuration: they can just run `M-x list-packages` and install it out of the box. We hope that this will improve Emacs and help bring new users to this package and others.

The main difference between NonGNU ELPA and MELPA is that only stable versions of packages are released. A new release will be made automatically when you bump the "Version" commentary header in this repository, as I do in this commit. In the future, you can bump the package version (thereby releasing a new version) when you think it makes sense and at your convenience.

Please let me know if you have any questions about NonGNU ELPA.

Thanks!