### PR TITLE
Use plural in package name and add matching library

### DIFF
--- a/spacemacs-dark-theme.el
+++ b/spacemacs-dark-theme.el
@@ -1,4 +1,4 @@
-(require 'spacemacs-common)
+(require 'spacemacs-themes)
 
 (deftheme spacemacs-dark "Spacemacs theme, the dark version")
 

--- a/spacemacs-light-theme.el
+++ b/spacemacs-light-theme.el
@@ -1,4 +1,4 @@
-(require 'spacemacs-common)
+(require 'spacemacs-themes)
 
 (deftheme spacemacs-light "Spacemacs theme, the light version")
 

--- a/spacemacs-theme-pkg.el
+++ b/spacemacs-theme-pkg.el
@@ -1,1 +1,0 @@
-(define-package "spacemacs-theme" "0.2" "Color theme with a dark and light versions" 'nil :url "https://github.com/nashamri/spacemacs-theme" :keywords '("color" "theme"))

--- a/spacemacs-themes-pkg.el
+++ b/spacemacs-themes-pkg.el
@@ -1,0 +1,5 @@
+(define-package "spacemacs-themes" "0.2"
+  "Color theme with a dark and light versions."
+  nil
+  :url "https://github.com/nashamri/spacemacs-theme"
+  :keywords '("color" "theme"))

--- a/spacemacs-themes.el
+++ b/spacemacs-themes.el
@@ -1,4 +1,4 @@
-;;; spacemacs-common.el --- Color theme with a dark and light versions.
+;;; spacemacs-themes.el --- Color theme with a dark and light versions.
 
 ;; Copyright (C) 2015-2018 Nasser Alshammari
 
@@ -1060,10 +1060,10 @@ to 'auto, tags may not be properly aligned. "
   (add-to-list 'custom-theme-load-path
                (file-name-as-directory (file-name-directory load-file-name))))
 
-(provide 'spacemacs-common)
+(provide 'spacemacs-themes)
 
 ;; Local Variables:
 ;; no-byte-compile: t
 ;; End:
 
-;;; spacemacs-common.el ends here
+;;; spacemacs-themes.el ends here


### PR DESCRIPTION
This replaces #63.  Also discussed at ~~https://github.com/melpa/melpa/issues/821~~. Edit: Sorry linked wrong issue. I meant https://github.com/melpa/melpa/issues/8219.

Every package should provide a library whose name matches that of the
package.  This allows tools, such as those used by Melpa, to extract
metadata.

At the same time every library named "...-theme.el" must itself
implement a theme because `load-theme` unfortunately assumes that
every file on `custom-theme-load-path` with such a name actually
provides a theme.  If it encounters files that to not provide a theme
but are never-the-less named "...-theme.el", then it falsely offers
those as themes, and trying to activate them will result in errors.

Furthermore, since this package provides multiple themes, it makes
sense to give it a name that suggests so.

Unfortunately package.el does not (yet?) support informing the user
about package renames or even automatically updating to the new name,
so some users will not notice this rename for a while.  Add a note
at the beginning of the readme, in the hope that will help at least
some users.