### PR TITLE
Improve lazy-highlight

### DIFF
--- a/spacemacs-theme.el
+++ b/spacemacs-theme.el
@@ -195,7 +195,7 @@ to 'auto, tags may not be properly aligned. "
      `(highlight ((,class (:foreground ,base :background ,highlight))))
      `(hl-line ((,class (:background ,bg2 :extend t))))
      `(isearch ((,class (:foreground ,bg1 :background ,mat))))
-     `(lazy-highlight ((,class (:background ,green-bg-s :weight normal))))
+     `(lazy-highlight ((,class (:background ,green-bg-s))))
      `(link ((,class (:foreground ,comment :underline t))))
      `(link-visited ((,class (:foreground ,comp :underline t))))
      `(match ((,class (:background ,highlight :foreground ,mat))))


### PR DESCRIPTION
This PR makes the font weight of `lazy-highlight`consistent with the other faces when default font is set not to `normal`.

before:
<img width="510" alt="Screen Shot 2024-07-15 at 2 09 58 PM" src="https://github.com/user-attachments/assets/1b5d694c-6986-4b6b-a2f8-4b53cb935852">
after:
<img width="518" alt="Screen Shot 2024-07-15 at 2 10 56 PM" src="https://github.com/user-attachments/assets/0cf0cf85-6c33-4da2-a74d-23d510625aa0">
