### PR TITLE
Add support for dired-subtree

### DIFF
--- a/spacemacs-theme.el
+++ b/spacemacs-theme.el
@@ -334,6 +334,14 @@ to 'auto, tags may not be properly aligned. "
      `(dired-symlink ((,class (:foreground ,cyan :background ,bg1 :inherit bold))))
      `(dired-warning ((,class (:foreground ,war))))
 
+;;;;; dired-subtree
+     `(dired-subtree-depth-1-face ((,class (:background ,bg1))))
+     `(dired-subtree-depth-2-face ((,class (:background ,bg1))))
+     `(dired-subtree-depth-3-face ((,class (:background ,bg1))))
+     `(dired-subtree-depth-4-face ((,class (:background ,bg1))))
+     `(dired-subtree-depth-5-face ((,class (:background ,bg1))))
+     `(dired-subtree-depth-6-face ((,class (:background ,bg1))))
+
 ;;;;; doom-modeline
      `(doom-modeline-bar ((,class (:background ,keyword))))
 


### PR DESCRIPTION
Added faces for dired-subtree. I originally struggled with whether or not to use different dark background colors to represent the depths, but then I referred to [comment](https://github.com/protesilaos/modus-themes/blob/613f95341246746c3def202e67b27a315560d6f4/modus-themes.el#L2180-L2183) in modus-theme and found that it worked well, as there're only four different dark background colors provided in spacemacs-theme, but dired-subtree defines six subtree depth faces.