### PR TITLE
Make diff-refine faces readable and compatible with font-lock

### DIFF
--- a/spacemacs-theme.el
+++ b/spacemacs-theme.el
@@ -314,17 +314,17 @@ to `auto', tags may not be properly aligned. "
      `(corfu-current ((,class (:background ,ttip-sl :foreground ,base))))
 
 ;;;;; diff
-     `(diff-added             ((,class :background unspecified :foreground ,green :extend t)))
-     `(diff-changed           ((,class :background unspecified :foreground ,blue)))
+     `(diff-added             ((,class :background ,green-bg :extend t)))
+     `(diff-changed           ((,class :background ,blue-bg)))
      `(diff-header            ((,class :background ,cblk-ln-bg :foreground ,func :extend t)))
      `(diff-file-header       ((,class :background ,cblk-ln-bg :foreground ,cblk :extend t)))
-     `(diff-indicator-added   ((,class :background unspecified :foreground ,green :extend t)))
-     `(diff-indicator-changed ((,class :background unspecified :foreground ,blue)))
-     `(diff-indicator-removed ((,class :background unspecified :foreground ,red)))
-     `(diff-refine-added      ((,class :background ,green :foreground ,bg1)))
-     `(diff-refine-changed    ((,class :background ,blue :foreground ,bg1)))
-     `(diff-refine-removed    ((,class :background ,red :foreground ,bg1)))
-     `(diff-removed           ((,class :background unspecified :foreground ,red :extend t)))
+     `(diff-indicator-added   ((,class :background ,green-bg :extend t)))
+     `(diff-indicator-changed ((,class :background ,blue-bg)))
+     `(diff-indicator-removed ((,class :background ,red-bg)))
+     `(diff-refine-added      ((,class :background ,green-bg-s)))
+     `(diff-refine-changed    ((,class :background ,blue-bg-s)))
+     `(diff-refine-removed    ((,class :background ,red-bg-s)))
+     `(diff-removed           ((,class :background ,red-bg :extend t)))
 
 ;;;;; diff-hl
      `(diff-hl-insert ((,class :background ,green :foreground ,green)))


### PR DESCRIPTION
In particular, use background colors for both
diff-{added,changed,removed} and diff-refine-{added,changed,removed}. Changing the former allows diff-font-lock-syntax to function correctly and leave diffed code with proper syntax highlighting.

Change the `diff-refine-*` faces to use less harsh background colors (those actually intended for background use are named `*-bg*`), so that refined text is actually legible.

## before

<img width="1265" height="899" alt="image" src="https://github.com/user-attachments/assets/35c87d1e-0e7a-450a-aaa6-24f89626bd37" />

## after

<img width="1268" height="901" alt="image" src="https://github.com/user-attachments/assets/50d5225d-30f6-49b4-a0e3-827bd7a2f69c" />
