### PR TITLE
Add support for lsp-ui-peek

### DIFF
--- a/spacemacs-theme.el
+++ b/spacemacs-theme.el
@@ -725,11 +725,11 @@ to `auto', tags may not be properly aligned. "
      `(lsp-ui-doc-header ((,class (:foreground ,head1 :background ,head1-bg))))
      `(lsp-ui-sideline-code-action ((,class (:foreground ,comp))))
      `(lsp-ui-peek-header ((,class (:foreground ,bg1 :background ,base))))
-     `(lsp-ui-peek-peek ((,class (:background ,bg3))))
-     `(lsp-ui-peek-list ((,class (:background ,bg3))))
+     `(lsp-ui-peek-peek ((,class (:background ,bg2))))
+     `(lsp-ui-peek-list ((,class (:background ,bg2))))
      `(lsp-ui-peek-highlight ((,class (:background ,highlight))))
      `(lsp-ui-peek-line-number ((,class (:foreground ,base))))
-     `(lsp-ui-peek-selection ((,class (:background ,bg4))))
+     `(lsp-ui-peek-selection ((,class (:background ,bg3))))
      `(lsp-ui-peek-filename ((,class (:foreground ,base))))
 
 ;;;;; magit

--- a/spacemacs-theme.el
+++ b/spacemacs-theme.el
@@ -724,6 +724,13 @@ to `auto', tags may not be properly aligned. "
      `(lsp-ui-doc-background ((,class (:background ,bg2))))
      `(lsp-ui-doc-header ((,class (:foreground ,head1 :background ,head1-bg))))
      `(lsp-ui-sideline-code-action ((,class (:foreground ,comp))))
+     `(lsp-ui-peek-header ((,class (:foreground ,bg1 :background ,base))))
+     `(lsp-ui-peek-peek ((,class (:background ,bg3))))
+     `(lsp-ui-peek-list ((,class (:background ,bg3))))
+     `(lsp-ui-peek-highlight ((,class (:background ,highlight))))
+     `(lsp-ui-peek-line-number ((,class (:foreground ,base))))
+     `(lsp-ui-peek-selection ((,class (:background ,bg4))))
+     `(lsp-ui-peek-filename ((,class (:foreground ,base))))
 
 ;;;;; magit
      `(magit-blame-culprit ((,class :background ,yellow-bg :foreground ,yellow)))


### PR DESCRIPTION
## before:
<img width="1360" height="416" alt="Screenshot 2026-05-22 at 01 19 51" src="https://github.com/user-attachments/assets/d878304c-861b-4bb2-a63d-9875f5167f69" />

## after:
<img width="1390" height="458" alt="Screenshot 2026-05-22 at 01 18 30" src="https://github.com/user-attachments/assets/01c64d4c-97e0-4e87-93cf-5da08242986f" />
